### PR TITLE
try

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ Basically I am a user that loves GH notification instead of mails and I like to 
 ## What you can do for this project
 
 Use it :). Raise issues or request of features, improve UI.
+
+## Build instruction
+```zsh
+cargo run
+```

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -73,6 +73,7 @@ component MainWindow inherits Window {
 
                 Button {
                   text: "√";
+                  visible: n.unread;
                   width: 50px;
                   clicked => { mark-done(n.id); }
                 }


### PR DESCRIPTION
- **Hide `Mark Read` button if list is for already read**
  In the case of already read notification does not make sense to have the
  button for mark and done/read. In GH terms they use done/read as
  tification from the list of them. But that API at the moment is in

- **Doc: Add build instructions**
  This assumes you have rust installed :).
  
Signed-off-by: Federico Guerinoni <guerinoni.federico@gmail.com>
